### PR TITLE
define policy for func instead of creating lambda role

### DIFF
--- a/sam.yaml
+++ b/sam.yaml
@@ -105,32 +105,7 @@ Resources:
                 s3:x-amz-acl: "bucket-owner-full-control"
 
   #### Resources related to Lambda Function ####
-  # Role, Log Group, Function
-  
-  APITrackerLambdaRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          -
-            Effect: "Allow"
-            Principal:
-              Service: "lambda.amazonaws.com"
-            Action:
-              - "sts:AssumeRole"
-      ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-      Policies: 
-        - 
-          PolicyName: "WriteMetricToCW"
-          PolicyDocument: 
-            Version: "2012-10-17"
-            Statement:
-              -
-                Effect: "Allow"
-                Action: "cloudwatch:PutMetricData"
-                Resource: "*"
+  # Log Group, Function
   
   APITrackerCWLogs:
       Type: 'AWS::Logs::LogGroup'
@@ -147,7 +122,8 @@ Resources:
       Description: "Send CloudTrail Event Counts to CloudWatch Metrics"
       MemorySize: 128
       Timeout: 10
-      Role: !GetAtt [ APITrackerLambdaRole, Arn ]
+      Policies:
+        - CloudWatchPutMetricPolicy: {}
 
   #### Resources for CW Logs to Lambda ####
   # CW Log Filter, Lambda Permission


### PR DESCRIPTION
Simplified SAM template to just use policy inline with the function, rather than creating a role.
Works as expected in my test before I committed to dev.